### PR TITLE
Never return fields not saved in Dynamo on create

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -240,7 +240,6 @@ describe("omanyd", () => {
 
       expect(savedThing).toStrictEqual({
         id: savedThing.id,
-        value: undefined,
       });
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,8 +27,8 @@ export function define<T>(options: Options) {
   return {
     async create(obj: Omit<T, "id"> | T): Promise<T> {
       const validated: T = await validator.validateAsync(obj);
-      await t.create(validated);
-      return validated;
+      const result = await t.create(validated);
+      return (result as unknown) as T;
     },
 
     async put(obj: T): Promise<T> {


### PR DESCRIPTION
If an object containing undefined was provided to create then this
undefined field would be returned but not on read. This was confusing.

This guarantees that we treat them the same.