### PR TITLE
bug: Apply Joi defaults after saving

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -242,6 +242,26 @@ describe("omanyd", () => {
         id: savedThing.id,
       });
     });
+
+    it("should save and return empty arrays", async () => {
+      interface Thing {
+        id: string;
+        list: string[];
+      }
+      const ThingStore = Omanyd.define<Thing>({
+        name: "basicEmptyArray",
+        hashKey: "id",
+        schema: Joi.object({
+          id: Omanyd.types.id(),
+          list: Joi.array().items(Joi.string()).default([]),
+        }),
+      });
+
+      await Omanyd.createTables();
+
+      const savedThing = await ThingStore.create({ list: [] });
+      expect(savedThing.list).toEqual([]);
+    });
   });
 
   describe("range key", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,8 @@ export function define<T extends PlainObject>(options: Options) {
     async create(obj: Omit<T, "id"> | T): Promise<T> {
       const validated: T = await validator.validateAsync(obj);
       const result = await t.create(validated);
-      return result as unknown as T;
+      const validatedResult = await validator.validateAsync(result);
+      return validatedResult as unknown as T;
     },
 
     async put(obj: T): Promise<T> {


### PR DESCRIPTION
When saving an empty list then dynamodb drops them and so the result from create does not have them. We now validate the create result to ensure it matches the schema. This should have been as we need to guarantee the first item we save matches our expected schema.